### PR TITLE
Modify hook_page_attachments() by hook_form_FORM_ID_alter()

### DIFF
--- a/floating_action_buttons.module
+++ b/floating_action_buttons.module
@@ -1,14 +1,16 @@
 <?php
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
- * Implements hook_page_attachments().
+ * Implements hook_form_FORM_ID_alter().
  */
-function floating_action_buttons_page_attachments(array &$attachments) {
-   $systemTheme = \Drupal::config('system.theme');
-   $admin = $systemTheme->get('admin');
-   $default = $systemTheme->get('default');
-   $theme = \Drupal::theme()->getActiveTheme()->getName();
-   if ($theme == $admin || $theme == $default) {
-      $attachments['#attached']['library'][] = 'floating_action_buttons/floating_action_buttons.admin';
-   }
+function floating_action_buttons_form_node_form_alter(array &$form, FormStateInterface $form_state) {
+  $systemTheme = \Drupal::config('system.theme');
+  $admin = $systemTheme->get('admin');
+  $default = $systemTheme->get('default');
+  $theme = \Drupal::theme()->getActiveTheme()->getName();
+  if ($theme === $admin || $theme === $default) {
+    $form['#attached']['library'][] = 'floating_action_buttons/floating_action_buttons.admin';
+  }
 }


### PR DESCRIPTION
As we are currently targeting node entities, i propose to add more context and replace hook_page_attachments() by hook_form_FORM_ID_alter(). It also allows to alter / unset the library if needed on a more local hook and thus have fine-grained alteration, e.g. based on form operations.